### PR TITLE
Update React to 0.13.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     middleman-react (0.12.1.1)
       execjs
       middleman-core (>= 3.0)
-      react-source (~> 0.12.1)
+      react-source (~> 0.13.1)
 
 GEM
   remote: https://rubygems.org/
@@ -103,7 +103,7 @@ GEM
       ffi (>= 0.5.0)
     rdoc (3.12.2)
       json (~> 1.4)
-    react-source (0.12.1)
+    react-source (0.13.1)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)

--- a/middleman-react.gemspec
+++ b/middleman-react.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "middleman-core", [">= 3.0"]
   gem.add_dependency "execjs"
-  gem.add_dependency "react-source", "~> 0.12.1"
+  gem.add_dependency "react-source", "~> 0.13.1"
 
   gem.add_development_dependency "aruba"
   gem.add_development_dependency "cane"

--- a/spec/features/coffeescript.feature
+++ b/spec/features/coffeescript.feature
@@ -14,7 +14,7 @@ Feature: Transforming JSX into Javascript when it is written in Coffeescript
       /** @jsx React.DOM */
 
       (function() {
-        this.app.components.test = React.createClass({displayName: 'test',
+        this.app.components.test = React.createClass({displayName: "test",
           render: function() {
             return React.createElement("div", null, 
             React.createElement(TestComponent, {data: this.props.someData})


### PR DESCRIPTION
The specs weren't running on Ruby 2.2.1, and one was failing, so this also updates rubocop and Cucumber, and fixes the coffeescript spec that was failing.