### PR TITLE
cjsx support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     middleman-react (0.13.3)
+      coffee-react
       execjs
       middleman-core (>= 3.0)
       react-source (~> 0.13.3)
@@ -31,6 +32,8 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     chunky_png (1.3.4)
     coderay (1.1.0)
+    coffee-react (3.0.1)
+      execjs
     coffee-script (2.4.1)
       coffee-script-source
       execjs

--- a/fixtures/app/source/assets/javascripts/cjsx_component.cjsx
+++ b/fixtures/app/source/assets/javascripts/cjsx_component.cjsx
@@ -1,0 +1,7 @@
+###* @jsx React.DOM ###
+
+@app.components.test = React.createClass
+  render: ->
+    <div>
+      <TestComponent data={this.props.someData} />
+    </div>

--- a/lib/middleman-react/cjsx/template.rb
+++ b/lib/middleman-react/cjsx/template.rb
@@ -1,11 +1,12 @@
 # encoding: UTF-8
 
 require 'tilt'
+require 'coffee-react'
 
 module Middleman
   module React
-    module JSX
-      # Tilt Tempalte for handling JSX files
+    module CJSX
+      # Tilt Tempalte for handling CJSX files
       class Template < Tilt::Template
         self.default_mime_type = 'application/javascript'
 
@@ -25,7 +26,8 @@ module Middleman
         end
 
         def evaluate(_scope, _locals, &_block)
-          @output ||= JSX.transform(data, options)
+          @coffee ||= ::CoffeeReact.transform(data, options)
+          @output ||= ::CoffeeScript.compile @coffee
         end
       end
     end

--- a/lib/middleman-react/extension.rb
+++ b/lib/middleman-react/extension.rb
@@ -3,6 +3,7 @@
 require 'middleman-core'
 require 'middleman-react/jsx'
 require 'middleman-react/jsx/template'
+require 'middleman-react/cjsx/template'
 
 module Middleman
   module React
@@ -14,11 +15,20 @@ module Middleman
       def initialize(app, options_hash = {}, &block)
         super
 
-        Middleman::React::Template.harmony = options[:harmony]
-        Middleman::React::Template.strip_types = options[:strip_types]
+        Middleman::React::JSX::Template.harmony = options[:harmony]
+        Middleman::React::JSX::Template.strip_types = options[:strip_types]
+        Middleman::React::CJSX::Template.harmony = options[:harmony]
+        Middleman::React::CJSX::Template.strip_types = options[:strip_types]
 
-        ::Tilt.register 'jsx', Middleman::React::Template
-        ::Sprockets.register_engine 'jsx', Middleman::React::Template
+        ::Tilt.register 'jsx', Middleman::React::JSX::Template
+        ::Sprockets.register_engine 'jsx', Middleman::React::JSX::Template
+
+        ::Tilt.register 'cjsx', Middleman::React::CJSX::Template
+        ::Sprockets.register_engine 'cjsx', Middleman::React::CJSX::Template
+      end
+
+      def after_configuration
+        @app.template_extensions cjsx: :js, jsx: :js
       end
     end
   end

--- a/middleman-react.gemspec
+++ b/middleman-react.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'middleman-core', ['>= 3.0']
   gem.add_dependency 'execjs'
   gem.add_dependency 'react-source', '~> 0.13.3'
+  gem.add_dependency 'coffee-react'
 
   gem.add_development_dependency 'aruba'
   gem.add_development_dependency 'cane'

--- a/spec/features/coffeescript.feature
+++ b/spec/features/coffeescript.feature
@@ -26,3 +26,27 @@ Feature: Transforming JSX into Javascript when it is written in Coffeescript
 
       """
     And the exit status should be 0
+
+  Scenario: A CJSX file
+    When I cd to "build"
+    Then the following files should exist:
+      | assets/javascripts/cjsx_component.js |
+    When I run `cat assets/javascripts/cjsx_component.js`
+    Then the stdout from "cat assets/javascripts/cjsx_component.js" should contain exactly:
+      """
+
+      /** @jsx React.DOM */
+
+      (function() {
+        this.app.components.test = React.createClass({
+          render: function() {
+            return React.createElement("div", null, React.createElement(TestComponent, {
+              "data": this.props.someData
+            }));
+          }
+        });
+
+      }).call(this);
+
+      """
+    And the exit status should be 0


### PR DESCRIPTION
This pull requests brings in coffee-react, and provides native support for CJSX files.  This also fixes the extensions of jsx and cjsx files to include .js.
